### PR TITLE
Use openapi-spec-validator for version 2

### DIFF
--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -30,7 +30,7 @@ def validate_spec(spec):
             "    pip install 'apispec[validation]'",
         )
     parser_kwargs = {}
-    if spec.openapi_version.version[0] == 3:
+    if spec.openapi_version.version[0] in (2, 3):
         parser_kwargs['backend'] = 'openapi-spec-validator'
     try:
         prance.BaseParser(spec_string=json.dumps(spec.to_dict()), **parser_kwargs)


### PR DESCRIPTION
Use `openapi-spec-validator` for version 2

`flex` was throwing validation errors due to `default` settings in `field2property`